### PR TITLE
Add link for linux binaries to the packages from the openSUSE build system

### DIFF
--- a/home.php
+++ b/home.php
@@ -25,6 +25,7 @@
             &nbsp;&nbsp;Qt GUI and daemon.<br>
             &nbsp;&nbsp;<a target="_blank" href="https://github.com/namecoin/namecoin/tree/vQ.3.72">Sources on Github</a><br>
             &nbsp;&nbsp;<a href="http://namecoin.info/files/namecoin_win_vQ.3.72.zip">Windows binary</a><br>
+            &nbsp;&nbsp;<a href="http://software.opensuse.org/download.html?project=home%3Ap_conrad%3Acoins&package=namecoin">Linux packages</a><br>
             &nbsp;&nbsp;Mac binary - ?<br>
             &nbsp;&nbsp;<a target="_blank" href="https://bitcointalk.org/index.php?topic=236340.msg3436752#msg3436752">Hashes on Bitcointalk</a><br>
             <br>


### PR DESCRIPTION
Project URL : https://build.opensuse.org/package/show/home:p_conrad:coins/namecoin
Built packages : http://software.opensuse.org/download.html?project=home%3Ap_conrad%3Acoins&package=namecoin

I have created an account (khalahan) on openSUSE, asked access to PMC (p_conrad) and now have an admin access on the openSUSE project (the same you are able to do, padawan).

Source packages can be added manually or automatically from github releases/tags.
Once a source file is uploaded/url added, packages are rebuilt automatically.
