### PR TITLE
Revert "home: change in text forum link to active topics"

### DIFF
--- a/home.php
+++ b/home.php
@@ -26,7 +26,7 @@
     </div>
 </div>
 
-<p>Find more information in the <a href="https://wiki.namecoin.info">Namecoin wiki</a> or join us on the <a href="https://forum.namecoin.info/search.php?st=7&sk=t&sd=d&sr=topics&search_id=active_topics">Namecoin forum</a>.</p>
+<p>Find more information in the <a href="https://wiki.namecoin.info">Namecoin wiki</a> or join us on the <a href="https://forum.namecoin.info">Namecoin forum</a>.</p>
 
 <div class="row">
     <h2>News</h2>


### PR DESCRIPTION
Reverts namecoin/namecoin.info#129 . This was merged despite the only review being a NACK, and should never have been merged.  I'm reverting it myself because the author of the original PR has not responded to complaints for a week.